### PR TITLE
Overhaul student management and add teacher directory

### DIFF
--- a/app/Http/Controllers/JournalController.php
+++ b/app/Http/Controllers/JournalController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Group;
+use App\Models\Lesson;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class JournalController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $groups = Group::orderBy('name')->get(['id', 'name']);
+
+        $selectedGroupId = $request->integer('group_id');
+        $selectedGroup = null;
+        $lessons = collect();
+        $students = collect();
+
+        if ($selectedGroupId) {
+            $selectedGroup = Group::with([
+                'students' => fn ($query) => $query->orderBy('name'),
+                'lessons' => fn ($query) => $query
+                    ->orderBy('week_number')
+                    ->orderBy('lesson_date')
+                    ->orderBy('day_of_week')
+                    ->orderBy('start_time'),
+            ])->find($selectedGroupId);
+
+            if ($selectedGroup) {
+                $lessons = $selectedGroup->lessons;
+                $students = $selectedGroup->students;
+            }
+        }
+
+        $selectedLessonId = $request->integer('lesson_id');
+        $selectedLesson = null;
+
+        if ($lessons->isNotEmpty()) {
+            if ($selectedLessonId) {
+                $selectedLesson = $lessons->firstWhere('id', $selectedLessonId);
+            }
+
+            if (! $selectedLesson) {
+                $today = Carbon::today();
+                $selectedLesson = $lessons->first(function (Lesson $lesson) use ($today) {
+                    return $lesson->lesson_date && $lesson->lesson_date->greaterThanOrEqualTo($today);
+                }) ?? $lessons->first();
+
+                $selectedLessonId = $selectedLesson?->id;
+            }
+        }
+
+        return view('journal.index', [
+            'groups' => $groups,
+            'selectedGroup' => $selectedGroup,
+            'students' => $students,
+            'lessons' => $lessons,
+            'selectedLesson' => $selectedLesson,
+            'selectedLessonId' => $selectedLessonId,
+        ]);
+    }
+}

--- a/app/Http/Controllers/TeacherController.php
+++ b/app/Http/Controllers/TeacherController.php
@@ -8,20 +8,20 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
 
-class StudentController extends Controller
+class TeacherController extends Controller
 {
     public function index(): View
     {
-        $students = User::where('role', 'student')
+        $teachers = User::where('role', 'teacher')
             ->orderBy('name')
             ->get();
 
-        return view('students.index', compact('students'));
+        return view('teachers.index', compact('teachers'));
     }
 
     public function create(): View
     {
-        return view('students.create');
+        return view('teachers.create');
     }
 
     public function store(Request $request): RedirectResponse
@@ -40,42 +40,42 @@ class StudentController extends Controller
             'iin' => $validated['iin'],
             'email' => $validated['email'],
             'password' => Hash::make($validated['password']),
-            'role' => 'student',
+            'role' => 'teacher',
             'phone' => $validated['phone'] ?? null,
             'birth_date' => $validated['birth_date'] ?? null,
             'is_active' => true,
         ]);
 
-        return redirect()->route('students.index')->with('status', 'Ученик создан.');
+        return redirect()->route('teachers.index')->with('status', 'Учитель создан.');
     }
 
-    public function show(User $student): View
+    public function show(User $teacher): View
     {
-        abort_unless($student->role === 'student', 404);
+        abort_unless($teacher->role === 'teacher', 404);
 
-        return view('students.show', compact('student'));
+        return view('teachers.show', compact('teacher'));
     }
 
-    public function edit(User $student): View
+    public function edit(User $teacher): View
     {
-        abort_unless($student->role === 'student', 404);
+        abort_unless($teacher->role === 'teacher', 404);
 
-        return view('students.edit', compact('student'));
+        return view('teachers.edit', compact('teacher'));
     }
 
-    public function update(Request $request, User $student): RedirectResponse
+    public function update(Request $request, User $teacher): RedirectResponse
     {
-        abort_unless($student->role === 'student', 404);
+        abort_unless($teacher->role === 'teacher', 404);
 
         $validated = $request->validate([
             'name' => ['required', 'string', 'max:255'],
-            'iin' => ['required', 'string', 'regex:/^\d{12}$/', 'unique:users,iin,' . $student->id],
-            'email' => ['required', 'email', 'max:255', 'unique:users,email,' . $student->id],
+            'iin' => ['required', 'string', 'regex:/^\d{12}$/', 'unique:users,iin,' . $teacher->id],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email,' . $teacher->id],
             'phone' => ['nullable', 'string', 'max:50'],
             'birth_date' => ['nullable', 'date'],
         ]);
 
-        $student->update([
+        $teacher->update([
             'name' => $validated['name'],
             'iin' => $validated['iin'],
             'email' => $validated['email'],
@@ -83,37 +83,37 @@ class StudentController extends Controller
             'birth_date' => $validated['birth_date'] ?? null,
         ]);
 
-        return redirect()->route('students.index')->with('status', 'Ученик обновлён.');
+        return redirect()->route('teachers.index')->with('status', 'Учитель обновлён.');
     }
 
-    public function editPassword(User $student): View
+    public function destroy(User $teacher): RedirectResponse
     {
-        abort_unless($student->role === 'student', 404);
+        abort_unless($teacher->role === 'teacher', 404);
 
-        return view('students.password', compact('student'));
+        $teacher->delete();
+
+        return redirect()->route('teachers.index')->with('status', 'Учитель удален.');
     }
 
-    public function updatePassword(Request $request, User $student): RedirectResponse
+    public function editPassword(User $teacher): View
     {
-        abort_unless($student->role === 'student', 404);
+        abort_unless($teacher->role === 'teacher', 404);
+
+        return view('teachers.password', compact('teacher'));
+    }
+
+    public function updatePassword(Request $request, User $teacher): RedirectResponse
+    {
+        abort_unless($teacher->role === 'teacher', 404);
 
         $validated = $request->validate([
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
 
-        $student->update([
+        $teacher->update([
             'password' => Hash::make($validated['password']),
         ]);
 
-        return redirect()->route('students.show', $student)->with('status', 'Пароль обновлён.');
-    }
-
-    public function destroy(User $student): RedirectResponse
-    {
-        abort_unless($student->role === 'student', 404);
-
-        $student->delete();
-
-        return redirect()->route('students.index')->with('status', 'Ученик удален.');
+        return redirect()->route('teachers.show', $teacher)->with('status', 'Пароль обновлён.');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
+        'iin',
         'password',
         'role',
         'school_id',

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,6 +26,7 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'iin' => fake()->unique()->numerify(str_repeat('#', 12)),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_09_15_171000_add_iin_to_users_table.php
+++ b/database/migrations/2025_09_15_171000_add_iin_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('iin', 12)->nullable()->unique()->after('email');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_iin_unique');
+            $table->dropColumn('iin');
+        });
+    }
+};

--- a/resources/views/groups/index.blade.php
+++ b/resources/views/groups/index.blade.php
@@ -18,13 +18,15 @@
 @section('content')
     @include('partials.flash')
 
+    @php($columnWidth = '234.672px')
+
     <div class="card overflow-hidden">
         <div class="card-body p-0 overflow-x-auto">
             <table id="groupsTable" class="table table-striped dataTable w-100">
                 <colgroup>
-                    <col data-dt-column="0" style="width: 234.672px;">
-                    <col data-dt-column="1" style="width: 234.672px;">
-                    <col data-dt-column="2" style="width: 234.672px;">
+                    <col data-dt-column="0" style="width: {{ $columnWidth }};">
+                    <col data-dt-column="1" style="width: {{ $columnWidth }};">
+                    <col data-dt-column="2" style="width: {{ $columnWidth }};">
                 </colgroup>
                 <thead>
                     <tr role="row">
@@ -92,13 +94,16 @@
                 return;
             }
 
+            const columnWidth = @json($columnWidth);
+
             new DataTable(tableEl, {
                 paging: true,
                 searching: true,
                 info: false,
                 lengthChange: false,
                 columnDefs: [
-                    { orderable: false, targets: [2] },
+                    { width: columnWidth, targets: [0, 1] },
+                    { orderable: false, width: columnWidth, targets: [2] },
                 ],
                 language: {
                     search: 'Поиск:',

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -5,50 +5,240 @@
 @section('page_subtitle', 'Группа')
 
 @section('page_actions')
-    <a href="{{ route('groups.edit', $group) }}" class="btn btn-outline-gray">Редактировать</a>
     <a href="{{ route('groups.index') }}" class="btn btn-outline-gray">К списку</a>
 @endsection
 
 @section('content')
     @include('partials.flash')
 
-    <div class="bg-white border border-gray-100 rounded-16 p-24 mb-24">
-        <div class="row g-4">
-            <div class="col-md-4">
-                <div class="text-gray-400 text-sm">Курс</div>
-                <div class="fw-semibold">{{ $group->course?->name ?? '—' }}</div>
-            </div>
-            <div class="col-md-4">
-                <div class="text-gray-400 text-sm">Преподаватель</div>
-                <div>{{ $group->teacher?->name ?? 'Не назначен' }}</div>
-            </div>
-            <div class="col-md-4">
-                <div class="text-gray-400 text-sm">Учебный год</div>
-                <div>{{ $group->academicYear?->name ?? '—' }}</div>
-            </div>
-            <div class="col-md-4">
-                <div class="text-gray-400 text-sm">Язык</div>
-                <div>{{ $group->language }}</div>
-            </div>
-            <div class="col-md-4">
-                <div class="text-gray-400 text-sm">Статус</div>
-                <div>
-                    <span class="badge rounded-pill {{ $group->is_active ? 'bg-success-100 text-success-600' : 'bg-gray-100 text-gray-500' }}">
-                        {{ $group->is_active ? 'Активна' : 'Архив' }}
+    @php
+        $weekdayNames = [
+            1 => 'Понедельник',
+            2 => 'Вторник',
+            3 => 'Среда',
+            4 => 'Четверг',
+            5 => 'Пятница',
+            6 => 'Суббота',
+            7 => 'Воскресенье',
+        ];
+        $formatTime = static fn (?string $time) => $time ? mb_substr($time, 0, 5) : null;
+        $highlightLessonId = $nextLesson?->id ?? null;
+    @endphp
+
+    <div class="bg-white border border-gray-100 rounded-16 mb-24">
+        <div class="px-24 pt-24 pb-16 border-bottom">
+            <ul class="nav nav-pills gap-2 flex-wrap" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <a href="{{ route('groups.edit', $group) }}" class="nav-link text-sm fw-semibold">
+                        Изменить информацию о группе
+                    </a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <span class="nav-link active text-sm fw-semibold disabled" aria-current="page">
+                        Расписание группы
                     </span>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a href="{{ route('journal.index', ['group_id' => $group->id]) }}" class="nav-link text-sm fw-semibold">
+                        Журнал посещаемости
+                    </a>
+                </li>
+            </ul>
+        </div>
+        <div class="px-24 pb-24">
+            <div class="row g-4">
+                <div class="col-md-4">
+                    <div class="text-gray-400 text-sm">Курс</div>
+                    <div class="fw-semibold">{{ $group->course?->name ?? '—' }}</div>
+                </div>
+                <div class="col-md-4">
+                    <div class="text-gray-400 text-sm">Преподаватель</div>
+                    <div>{{ $group->teacher?->name ?? 'Не назначен' }}</div>
+                </div>
+                <div class="col-md-4">
+                    <div class="text-gray-400 text-sm">Учебный год</div>
+                    <div>{{ $group->academicYear?->name ?? '—' }}</div>
+                </div>
+                <div class="col-md-4">
+                    <div class="text-gray-400 text-sm">Язык</div>
+                    <div>{{ $group->language }}</div>
+                </div>
+                <div class="col-md-4">
+                    <div class="text-gray-400 text-sm">Статус</div>
+                    <div>
+                        <span class="badge rounded-pill {{ $group->is_active ? 'bg-success-100 text-success-600' : 'bg-gray-100 text-gray-500' }}">
+                            {{ $group->is_active ? 'Активна' : 'Архив' }}
+                        </span>
+                    </div>
+                </div>
+                <div class="col-12">
+                    <div class="text-gray-400 text-sm mb-1">Описание</div>
+                    <div>{{ $group->description ?: 'Описание не заполнено.' }}</div>
                 </div>
             </div>
-            <div class="col-12">
-                <div class="text-gray-400 text-sm mb-1">Описание</div>
-                <div>{{ $group->description ?: 'Описание не заполнено.' }}</div>
+
+            @if ($nextLesson)
+                @php
+                    $nextLessonWeekdayIndex = $nextLesson->day_of_week ?? $nextLesson->lesson_date?->dayOfWeekIso;
+                    $nextLessonWeekday = $nextLessonWeekdayIndex ? ($weekdayNames[$nextLessonWeekdayIndex] ?? null) : null;
+                    $nextLessonStart = $formatTime($nextLesson->start_time);
+                    $nextLessonEnd = $formatTime($nextLesson->end_time);
+                @endphp
+                <div class="bg-main-50 border border-main-100 rounded-12 p-20 mt-24">
+                    <div class="d-flex flex-column flex-lg-row gap-16 justify-content-between">
+                        <div>
+                            <div class="text-sm text-main-500 fw-semibold text-uppercase mb-2">Ближайшее занятие</div>
+                            <div class="fw-semibold text-gray-900">{{ $nextLesson->subject ?? 'Без предмета' }}</div>
+                            <div class="text-sm text-gray-400">
+                                @if ($nextLessonWeekday)
+                                    {{ $nextLessonWeekday }},
+                                @endif
+                                {{ $nextLesson->formatted_date ?: 'Дата не указана' }}
+                                @if ($nextLessonStart)
+                                    • {{ $nextLessonStart }}–{{ $nextLessonEnd ?? '—' }}
+                                @endif
+                                @if ($nextLesson->classroom)
+                                    • {{ $nextLesson->classroom }}
+                                @endif
+                            </div>
+                        </div>
+                        <div class="text-sm text-gray-400">
+                            @if ($nextLesson->topic)
+                                <div><span class="text-gray-300 fw-medium">Тема:</span> {{ $nextLesson->topic }}</div>
+                            @endif
+                            @if ($nextLesson->homework)
+                                <div class="mt-2"><span class="text-gray-300 fw-medium">ДЗ:</span> {{ $nextLesson->homework }}</div>
+                            @endif
+                            @unless ($nextLesson->topic || $nextLesson->homework)
+                                <div class="text-gray-300">Детали урока не заполнены.</div>
+                            @endunless
+                        </div>
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    <div class="bg-white border border-gray-100 rounded-16 mb-24">
+        <div class="px-24 pt-24 pb-16 border-bottom">
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-12">
+                <h5 class="mb-0">Расписание занятий</h5>
+                <span class="text-sm text-gray-300">Запланируйте занятия на нужное количество недель</span>
             </div>
+        </div>
+        <div class="px-24 pb-24">
+            @if ($lessonsByWeek->isEmpty())
+                <p class="text-gray-200 mb-0">Расписание ещё не создано. Добавьте занятия, чтобы увидеть их здесь.</p>
+            @else
+                @foreach ($lessonsByWeek as $weekNumber => $weekLessons)
+                    <div class="border border-gray-100 rounded-12 p-20 mb-24">
+                        <div class="d-flex flex-wrap justify-content-between align-items-center gap-12 mb-20">
+                            <div class="fw-semibold text-gray-900">Неделя {{ $weekNumber }}</div>
+                            <div class="text-sm text-gray-300">Всего занятий: {{ $weekLessons->count() }}</div>
+                        </div>
+
+                        <ul class="lesson-list list-unstyled mb-0">
+                            @foreach ($weekLessons as $lesson)
+                                @php
+                                    $weekdayIndex = $lesson->day_of_week ?? $lesson->lesson_date?->dayOfWeekIso;
+                                    $weekdayName = $weekdayIndex ? ($weekdayNames[$weekdayIndex] ?? null) : null;
+                                    $startTime = $formatTime($lesson->start_time);
+                                    $endTime = $formatTime($lesson->end_time);
+                                @endphp
+                                <li class="lesson-list__item {{ $lesson->id === $highlightLessonId ? 'active' : '' }}">
+                                    <div class="d-flex gap-16 align-items-start">
+                                        <span class="circle w-32 h-32 rounded-pill bg-white border border-main-100 flex-center text-13 fw-semibold text-gray-500">
+                                            {{ $loop->iteration }}
+                                        </span>
+                                        <div class="flex-grow-1">
+                                            <div class="d-flex flex-wrap gap-12 justify-content-between align-items-start">
+                                                <div>
+                                                    <div class="text-sm text-gray-400">
+                                                        {{ $weekdayName ? $weekdayName . ',' : '' }}
+                                                        {{ $lesson->formatted_date ?: 'Дата не указана' }}
+                                                    </div>
+                                                    <div class="fw-semibold text-gray-900">{{ $lesson->subject ?? 'Занятие' }}</div>
+                                                    <div class="text-13 text-gray-300">
+                                                        @if ($startTime)
+                                                            {{ $startTime }}–{{ $endTime ?? '—' }}
+                                                        @else
+                                                            Время не указано
+                                                        @endif
+                                                        @if ($lesson->classroom)
+                                                            • {{ $lesson->classroom }}
+                                                        @endif
+                                                    </div>
+                                                </div>
+                                                <span class="badge rounded-pill {{ $lesson->is_completed ? 'bg-success-100 text-success-600' : 'bg-main-100 text-main-600' }}">
+                                                    {{ $lesson->status }}
+                                                </span>
+                                            </div>
+
+                                            @if ($lesson->topic)
+                                                <div class="mt-12 text-13 text-gray-400">
+                                                    <span class="text-gray-300 fw-medium">Тема:</span> {{ $lesson->topic }}
+                                                </div>
+                                            @endif
+
+                                            @if ($lesson->homework)
+                                                <div class="mt-8 text-13 text-gray-400">
+                                                    <span class="text-gray-300 fw-medium">ДЗ:</span> {{ $lesson->homework }}
+                                                </div>
+                                            @endif
+
+                                            @if (! $lesson->topic && ! $lesson->homework)
+                                                <div class="mt-12 text-13 text-gray-200">Детали занятия ещё не заполнены.</div>
+                                            @endif
+                                        </div>
+                                    </div>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endforeach
+            @endif
+        </div>
+    </div>
+
+    <div class="bg-white border border-gray-100 rounded-16 mb-24">
+        <div class="px-24 pt-24 pb-16 border-bottom">
+            <div class="d-flex flex-wrap justify-content-between align-items-center gap-12">
+                <h5 class="mb-0">Календарно-тематическое планирование (КТП)</h5>
+                <span class="text-sm text-gray-300">Дата проставляется автоматически по занятию</span>
+            </div>
+        </div>
+        <div class="px-24 pb-24">
+            @if ($group->lessons->isEmpty())
+                <p class="text-gray-200 mb-0">После создания занятий заполните темы и домашние задания для КТП.</p>
+            @else
+                <div class="table-responsive">
+                    <table class="table align-middle">
+                        <thead>
+                            <tr>
+                                <th class="text-sm text-gray-400 fw-medium">Дата</th>
+                                <th class="text-sm text-gray-400 fw-medium">Тема урока</th>
+                                <th class="text-sm text-gray-400 fw-medium">ДЗ на урок</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($group->lessons as $lesson)
+                                <tr class="{{ $lesson->id === $highlightLessonId ? 'table-active' : '' }}">
+                                    <td class="text-nowrap">{{ $lesson->formatted_date ?: '—' }}</td>
+                                    <td>{{ $lesson->topic ?: 'Тема не заполнена' }}</td>
+                                    <td>{{ $lesson->homework ?: 'ДЗ не назначено' }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
         </div>
     </div>
 
     <div class="bg-white border border-gray-100 rounded-16 p-24">
         <h5 class="mb-16">Ученики группы ({{ $group->students->count() }})</h5>
         @if ($group->students->isEmpty())
-            <p class="text-gray-200 mb-0">В группу еще не добавлены ученики.</p>
+            <p class="text-gray-200 mb-0">В группу ещё не добавлены ученики.</p>
         @else
             <div class="table-responsive">
                 <table class="table align-middle">

--- a/resources/views/journal/index.blade.php
+++ b/resources/views/journal/index.blade.php
@@ -1,0 +1,274 @@
+@extends('welcome')
+
+@section('title', 'Журнал посещаемости')
+@section('page_title', 'Журнал посещаемости')
+@section('page_subtitle', 'Выберите группу и отметьте присутствие учеников на занятии')
+
+@section('content')
+    @include('partials.flash')
+
+    @php
+        $weekdayNames = [
+            1 => 'Понедельник',
+            2 => 'Вторник',
+            3 => 'Среда',
+            4 => 'Четверг',
+            5 => 'Пятница',
+            6 => 'Суббота',
+            7 => 'Воскресенье',
+        ];
+        $formatTime = static fn (?string $time) => $time ? mb_substr($time, 0, 5) : null;
+    @endphp
+
+    <div class="bg-white border border-gray-100 rounded-16 mb-24">
+        <div class="px-24 pt-24 pb-16 border-bottom">
+            <h5 class="mb-0">Выбор группы и занятия</h5>
+        </div>
+        <div class="px-24 pb-24">
+            <form method="GET" action="{{ route('journal.index') }}" class="row g-16 align-items-end">
+                <div class="col-12 col-lg-4">
+                    <label for="group_id" class="form-label text-sm text-gray-400">Группа</label>
+                    <select id="group_id" name="group_id" class="form-select" data-auto-submit>
+                        <option value="">Выберите группу</option>
+                        @foreach ($groups as $groupOption)
+                            <option value="{{ $groupOption->id }}" @selected($selectedGroup && $groupOption->id === $selectedGroup->id)>
+                                {{ $groupOption->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                @if ($selectedGroup && $lessons->isNotEmpty())
+                    <div class="col-12 col-lg-4">
+                        <label for="lesson_id" class="form-label text-sm text-gray-400">Занятие</label>
+                        <select id="lesson_id" name="lesson_id" class="form-select" data-auto-submit>
+                            @foreach ($lessons as $lessonOption)
+                                @php
+                                    $weekdayIndex = $lessonOption->day_of_week ?? $lessonOption->lesson_date?->dayOfWeekIso;
+                                    $weekdayName = $weekdayIndex ? ($weekdayNames[$weekdayIndex] ?? null) : null;
+                                    $startTime = $formatTime($lessonOption->start_time);
+                                    $endTime = $formatTime($lessonOption->end_time);
+                                @endphp
+                                <option value="{{ $lessonOption->id }}" @selected($selectedLesson && $lessonOption->id === $selectedLesson->id)>
+                                    {{ $lessonOption->formatted_date ?: 'Дата не указана' }}
+                                    @if ($weekdayName)
+                                        • {{ $weekdayName }}
+                                    @endif
+                                    @if ($startTime)
+                                        • {{ $startTime }}–{{ $endTime ?? '—' }}
+                                    @endif
+                                    @if ($lessonOption->subject)
+                                        • {{ $lessonOption->subject }}
+                                    @endif
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                @endif
+
+                <div class="col-12 col-lg-auto">
+                    <button type="submit" class="btn btn-main-600 w-100">Показать журнал</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    @if ($selectedGroup)
+        <div class="bg-white border border-gray-100 rounded-16">
+            <div class="px-24 pt-24 pb-16 border-bottom">
+                <div class="d-flex flex-wrap justify-content-between align-items-start gap-16">
+                    <div>
+                        <h5 class="mb-1">Журнал посещаемости</h5>
+                        <div class="text-sm text-gray-300">{{ $selectedGroup->name }}</div>
+                    </div>
+
+                    @if ($selectedLesson)
+                        @php
+                            $lessonWeekdayIndex = $selectedLesson->day_of_week ?? $selectedLesson->lesson_date?->dayOfWeekIso;
+                            $lessonWeekday = $lessonWeekdayIndex ? ($weekdayNames[$lessonWeekdayIndex] ?? null) : null;
+                            $lessonStart = $formatTime($selectedLesson->start_time);
+                            $lessonEnd = $formatTime($selectedLesson->end_time);
+                        @endphp
+                        <div class="text-sm text-gray-400 text-end">
+                            <div class="fw-semibold text-gray-900">{{ $selectedLesson->subject ?? 'Занятие' }}</div>
+                            <div>
+                                {{ $selectedLesson->formatted_date ?: 'Дата не указана' }}
+                                @if ($lessonWeekday)
+                                    • {{ $lessonWeekday }}
+                                @endif
+                                @if ($lessonStart)
+                                    • {{ $lessonStart }}–{{ $lessonEnd ?? '—' }}
+                                @endif
+                                @if ($selectedLesson->classroom)
+                                    • {{ $selectedLesson->classroom }}
+                                @endif
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            </div>
+
+            <div class="px-24 pb-24">
+                @if ($students->isEmpty())
+                    <p class="text-gray-200 mb-0">В группе пока нет учеников. Добавьте их, чтобы вести журнал посещаемости.</p>
+                @elseif (! $selectedLesson)
+                    <p class="text-gray-200 mb-0">Для выбранной группы ещё нет занятий. Создайте расписание, чтобы отмечать посещаемость.</p>
+                @else
+                    <div class="d-flex flex-wrap gap-12 align-items-center mb-20">
+                        <span class="badge rounded-pill bg-success-100 text-success-600">Присутствуют: <span data-attendance-present>0</span></span>
+                        <span class="badge rounded-pill bg-danger-100 text-danger-600">Отсутствуют: <span data-attendance-absent>0</span></span>
+                        <span class="badge rounded-pill bg-gray-100 text-gray-500">Без отметки: <span data-attendance-pending>{{ $students->count() }}</span></span>
+                    </div>
+
+                    <div id="attendance-feedback" class="alert alert-success d-none" role="alert">
+                        Отметки обновлены. Фактическое сохранение появится после подключения учёта посещаемости.
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table align-middle mb-20 attendance-table">
+                            <thead>
+                                <tr>
+                                    <th scope="col" class="text-gray-400 fw-medium">№</th>
+                                    <th scope="col" class="text-gray-400 fw-medium">ФИО ученика</th>
+                                    <th scope="col" class="text-gray-400 fw-medium text-center">Статус</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($students as $index => $student)
+                                    <tr class="attendance-row" data-student-id="{{ $student->id }}">
+                                        <td class="text-gray-400">{{ $index + 1 }}</td>
+                                        <td class="fw-semibold text-gray-900">{{ $student->name }}</td>
+                                        <td>
+                                            <div class="d-flex flex-column align-items-center gap-8">
+                                                <div class="d-flex gap-8">
+                                                    <input type="radio" class="btn-check attendance-toggle" name="attendance[{{ $student->id }}]" id="attendance-{{ $student->id }}-present" value="present">
+                                                    <label class="btn btn-outline-success btn-sm" for="attendance-{{ $student->id }}-present">Был</label>
+
+                                                    <input type="radio" class="btn-check attendance-toggle" name="attendance[{{ $student->id }}]" id="attendance-{{ $student->id }}-absent" value="absent">
+                                                    <label class="btn btn-outline-danger btn-sm" for="attendance-{{ $student->id }}-absent">Не был</label>
+                                                </div>
+                                                <span class="text-13 text-gray-300" data-attendance-label>Нет отметки</span>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-12 justify-content-between align-items-center">
+                        <p class="text-sm text-gray-300 mb-0">Отметьте посещаемость всех учеников и нажмите кнопку, чтобы зафиксировать результат.</p>
+                        <button type="button" class="btn btn-main-600" id="attendance-save" disabled>Сохранить отметки</button>
+                    </div>
+                @endif
+            </div>
+        </div>
+    @else
+        <div class="bg-white border border-dashed border-gray-100 rounded-16 p-32 text-center text-gray-200">
+            Выберите группу, чтобы открыть журнал посещаемости.
+        </div>
+    @endif
+@endsection
+
+@push('styles')
+    <style>
+        .attendance-row.is-present {
+            background-color: #ecfdf3;
+        }
+
+        .attendance-row.is-absent {
+            background-color: #fff1f2;
+        }
+
+        .attendance-table td,
+        .attendance-table th {
+            vertical-align: middle;
+        }
+    </style>
+@endpush
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const autoSubmitElements = document.querySelectorAll('[data-auto-submit]');
+            autoSubmitElements.forEach((element) => {
+                element.addEventListener('change', () => {
+                    if (element.form) {
+                        element.form.submit();
+                    }
+                });
+            });
+
+            const attendanceInputs = document.querySelectorAll('.attendance-toggle');
+            const presentTarget = document.querySelector('[data-attendance-present]');
+            const absentTarget = document.querySelector('[data-attendance-absent]');
+            const pendingTarget = document.querySelector('[data-attendance-pending]');
+            const saveButton = document.getElementById('attendance-save');
+            const feedback = document.getElementById('attendance-feedback');
+
+            const updateSummary = () => {
+                if (! presentTarget || ! absentTarget || ! pendingTarget) {
+                    return;
+                }
+
+                const presentCount = document.querySelectorAll('.attendance-toggle[value="present"]:checked').length;
+                const absentCount = document.querySelectorAll('.attendance-toggle[value="absent"]:checked').length;
+                const totalRows = document.querySelectorAll('.attendance-row').length;
+                const pendingCount = Math.max(totalRows - presentCount - absentCount, 0);
+
+                presentTarget.textContent = presentCount;
+                absentTarget.textContent = absentCount;
+                pendingTarget.textContent = pendingCount;
+            };
+
+            attendanceInputs.forEach((input) => {
+                input.addEventListener('change', () => {
+                    const row = input.closest('.attendance-row');
+                    const label = row ? row.querySelector('[data-attendance-label]') : null;
+
+                    if (row) {
+                        row.classList.remove('is-present', 'is-absent');
+                        if (input.checked) {
+                            if (input.value === 'present') {
+                                row.classList.add('is-present');
+                                if (label) {
+                                    label.textContent = 'Отмечен как присутствующий';
+                                    label.classList.remove('text-gray-300', 'text-danger-500');
+                                    label.classList.add('text-success-500');
+                                }
+                            } else if (input.value === 'absent') {
+                                row.classList.add('is-absent');
+                                if (label) {
+                                    label.textContent = 'Отмечен как отсутствующий';
+                                    label.classList.remove('text-gray-300', 'text-success-500');
+                                    label.classList.add('text-danger-500');
+                                }
+                            }
+                        }
+                    }
+
+                    if (saveButton) {
+                        saveButton.disabled = false;
+                    }
+
+                    if (feedback) {
+                        feedback.classList.add('d-none');
+                    }
+
+                    updateSummary();
+                });
+            });
+
+            if (saveButton) {
+                saveButton.addEventListener('click', () => {
+                    saveButton.disabled = true;
+                    if (feedback) {
+                        feedback.classList.remove('d-none');
+                    }
+                });
+            }
+
+            updateSummary();
+        });
+    </script>
+@endpush

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -4,6 +4,7 @@
 @section('page_title', 'Редактирование ученика')
 
 @section('page_actions')
+    <a href="{{ route('students.password.edit', $student) }}" class="btn btn-outline-gray">Изменить пароль</a>
     <a href="{{ route('students.index') }}" class="btn btn-outline-gray">Назад к списку</a>
 @endsection
 
@@ -21,75 +22,23 @@
             </div>
 
             <div class="col-md-6">
+                <label class="form-label fw-semibold">ИИН *</label>
+                <input type="text" name="iin" value="{{ old('iin', $student->iin) }}" class="form-control" inputmode="numeric" pattern="\d{12}" maxlength="12" placeholder="000000000000" required>
+            </div>
+
+            <div class="col-md-6">
                 <label class="form-label fw-semibold">Email *</label>
                 <input type="email" name="email" value="{{ old('email', $student->email) }}" class="form-control" required>
             </div>
 
             <div class="col-md-6">
-                <label class="form-label fw-semibold">Новый пароль</label>
-                <input type="password" name="password" class="form-control" placeholder="Оставьте пустым, чтобы не менять">
-            </div>
-
-            <div class="col-md-6">
-                <label class="form-label fw-semibold">Подтверждение пароля</label>
-                <input type="password" name="password_confirmation" class="form-control" placeholder="Повторите новый пароль">
-            </div>
-
-            <div class="col-md-4">
                 <label class="form-label fw-semibold">Телефон</label>
                 <input type="text" name="phone" value="{{ old('phone', $student->phone) }}" class="form-control" placeholder="+7 700 000 00 00">
             </div>
 
-            <div class="col-md-4">
+            <div class="col-md-6">
                 <label class="form-label fw-semibold">Дата рождения</label>
                 <input type="date" name="birth_date" value="{{ old('birth_date', optional($student->birth_date)->format('Y-m-d')) }}" class="form-control">
-            </div>
-
-            <div class="col-md-4">
-                <label class="form-label fw-semibold">Школа</label>
-                <select name="school_id" class="form-select">
-                    <option value="">Не указано</option>
-                    @foreach ($schools as $school)
-                        <option value="{{ $school->id }}" @selected(old('school_id', $student->school_id) == $school->id)>
-                            {{ $school->name }}
-                        </option>
-                    @endforeach
-                </select>
-            </div>
-
-            <div class="col-12">
-                <div class="form-check form-switch">
-                    <input class="form-check-input" type="checkbox" role="switch" name="is_active" id="student-active" value="1" @checked(old('is_active', $student->is_active))>
-                    <label class="form-check-label" for="student-active">Ученик активен</label>
-                </div>
-            </div>
-
-            <div class="col-md-6">
-                <label class="form-label fw-semibold">Группы</label>
-                <select name="group_ids[]" class="form-select" multiple size="6">
-                    @php
-                        $selectedGroups = collect(old('group_ids', $student->studentGroups->pluck('id')->all()));
-                    @endphp
-                    @foreach ($groups as $group)
-                        <option value="{{ $group->id }}" @selected($selectedGroups->contains($group->id))>
-                            {{ $group->name }}
-                        </option>
-                    @endforeach
-                </select>
-            </div>
-
-            <div class="col-md-6">
-                <label class="form-label fw-semibold">Курсы</label>
-                <select name="course_ids[]" class="form-select" multiple size="6">
-                    @php
-                        $selectedCourses = collect(old('course_ids', $student->courses->pluck('id')->all()));
-                    @endphp
-                    @foreach ($courses as $course)
-                        <option value="{{ $course->id }}" @selected($selectedCourses->contains($course->id))>
-                            {{ $course->name }}
-                        </option>
-                    @endforeach
-                </select>
             </div>
         </div>
 

--- a/resources/views/students/password.blade.php
+++ b/resources/views/students/password.blade.php
@@ -1,0 +1,35 @@
+@extends('welcome')
+
+@section('title', 'Смена пароля ученика')
+@section('page_title', 'Смена пароля')
+@section('page_subtitle', $student->name)
+
+@section('page_actions')
+    <a href="{{ route('students.show', $student) }}" class="btn btn-outline-gray">К профилю</a>
+    <a href="{{ route('students.index') }}" class="btn btn-outline-gray">К списку</a>
+@endsection
+
+@section('content')
+    @include('partials.flash')
+
+    <form action="{{ route('students.password.update', $student) }}" method="POST" class="bg-white border border-gray-100 rounded-16 p-24">
+        @csrf
+        @method('PUT')
+
+        <div class="row g-4">
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Новый пароль *</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Подтверждение пароля *</label>
+                <input type="password" name="password_confirmation" class="form-control" required>
+            </div>
+        </div>
+
+        <div class="mt-24 d-flex gap-12">
+            <button type="submit" class="btn btn-main">Сохранить</button>
+            <a href="{{ route('students.show', $student) }}" class="btn btn-outline-gray">Отмена</a>
+        </div>
+    </form>
+@endsection

--- a/resources/views/teachers/create.blade.php
+++ b/resources/views/teachers/create.blade.php
@@ -1,16 +1,16 @@
 @extends('welcome')
 
-@section('title', 'Новый ученик')
-@section('page_title', 'Добавление ученика')
+@section('title', 'Новый учитель')
+@section('page_title', 'Добавление учителя')
 
 @section('page_actions')
-    <a href="{{ route('students.index') }}" class="btn btn-outline-gray">Назад к списку</a>
+    <a href="{{ route('teachers.index') }}" class="btn btn-outline-gray">Назад к списку</a>
 @endsection
 
 @section('content')
     @include('partials.flash')
 
-    <form action="{{ route('students.store') }}" method="POST" class="bg-white border border-gray-100 rounded-16 p-24">
+    <form action="{{ route('teachers.store') }}" method="POST" class="bg-white border border-gray-100 rounded-16 p-24">
         @csrf
 
         <div class="row g-4">
@@ -52,7 +52,7 @@
 
         <div class="mt-24 d-flex gap-12">
             <button type="submit" class="btn btn-main">Сохранить</button>
-            <a href="{{ route('students.index') }}" class="btn btn-outline-gray">Отмена</a>
+            <a href="{{ route('teachers.index') }}" class="btn btn-outline-gray">Отмена</a>
         </div>
     </form>
 @endsection

--- a/resources/views/teachers/edit.blade.php
+++ b/resources/views/teachers/edit.blade.php
@@ -1,0 +1,50 @@
+@extends('welcome')
+
+@section('title', 'Редактирование учителя')
+@section('page_title', 'Редактирование учителя')
+
+@section('page_actions')
+    <a href="{{ route('teachers.password.edit', $teacher) }}" class="btn btn-outline-gray">Изменить пароль</a>
+    <a href="{{ route('teachers.index') }}" class="btn btn-outline-gray">Назад к списку</a>
+@endsection
+
+@section('content')
+    @include('partials.flash')
+
+    <form action="{{ route('teachers.update', $teacher) }}" method="POST" class="bg-white border border-gray-100 rounded-16 p-24">
+        @csrf
+        @method('PUT')
+
+        <div class="row g-4">
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">ФИО *</label>
+                <input type="text" name="name" value="{{ old('name', $teacher->name) }}" class="form-control" required>
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">ИИН *</label>
+                <input type="text" name="iin" value="{{ old('iin', $teacher->iin) }}" class="form-control" inputmode="numeric" pattern="\d{12}" maxlength="12" placeholder="000000000000" required>
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Email *</label>
+                <input type="email" name="email" value="{{ old('email', $teacher->email) }}" class="form-control" required>
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Телефон</label>
+                <input type="text" name="phone" value="{{ old('phone', $teacher->phone) }}" class="form-control" placeholder="+7 700 000 00 00">
+            </div>
+
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Дата рождения</label>
+                <input type="date" name="birth_date" value="{{ old('birth_date', optional($teacher->birth_date)->format('Y-m-d')) }}" class="form-control">
+            </div>
+        </div>
+
+        <div class="mt-24 d-flex gap-12">
+            <button type="submit" class="btn btn-main">Сохранить</button>
+            <a href="{{ route('teachers.index') }}" class="btn btn-outline-gray">Отмена</a>
+        </div>
+    </form>
+@endsection

--- a/resources/views/teachers/index.blade.php
+++ b/resources/views/teachers/index.blade.php
@@ -1,18 +1,18 @@
 @extends('welcome')
 
-@section('title', 'Ученики')
-@section('page_title', 'Ученики')
+@section('title', 'Учителя')
+@section('page_title', 'Учителя')
 
 @section('breadcrumb')
     <ul class="flex-align gap-4">
         <li><a href="{{ url('/') }}" class="text-gray-200 fw-normal text-15 hover-text-main-600">Главная</a></li>
         <li><span class="text-gray-500 fw-normal d-flex"><i class="ph ph-caret-right"></i></span></li>
-        <li><span class="text-main-600 fw-normal text-15">Ученики</span></li>
+        <li><span class="text-main-600 fw-normal text-15">Учителя</span></li>
     </ul>
 @endsection
 
 @section('page_actions')
-    <a href="{{ route('students.create') }}" class="btn btn-main">Добавить ученика</a>
+    <a href="{{ route('teachers.create') }}" class="btn btn-main">Добавить учителя</a>
 @endsection
 
 @section('content')
@@ -20,7 +20,7 @@
 
     <div class="card overflow-hidden">
         <div class="card-body p-0 overflow-x-auto">
-            <table id="studentsTable" class="table table-striped dataTable w-100">
+            <table id="teachersTable" class="table table-striped dataTable w-100">
                 <colgroup>
                     <col data-dt-column="0" style="width: 260px;">
                     <col data-dt-column="1" style="width: 180px;">
@@ -31,7 +31,7 @@
                 <thead>
                     <tr role="row">
                         <th class="h6 text-gray-300 dt-orderable-asc dt-orderable-desc" data-dt-column="0" tabindex="0">
-                            <span class="dt-column-title" role="button">Ученики</span>
+                            <span class="dt-column-title" role="button">Учителя</span>
                             <span class="dt-column-order"></span>
                         </th>
                         <th class="h6 text-gray-300 dt-orderable-asc dt-orderable-desc" data-dt-column="1" tabindex="0">
@@ -53,9 +53,9 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @forelse ($students as $student)
+                    @forelse ($teachers as $teacher)
                         @php
-                            $initial = mb_strtoupper(mb_substr($student->name, 0, 1));
+                            $initial = mb_strtoupper(mb_substr($teacher->name, 0, 1));
                         @endphp
                         <tr>
                             <td>
@@ -64,26 +64,26 @@
                                         {{ $initial }}
                                     </span>
                                     <div>
-                                        <a href="{{ route('students.show', $student) }}" class="h6 mb-0 fw-medium text-gray-900">{{ $student->name }}</a>
-                                        <div class="text-13 text-gray-300">{{ $student->email }}</div>
+                                        <a href="{{ route('teachers.show', $teacher) }}" class="h6 mb-0 fw-medium text-gray-900">{{ $teacher->name }}</a>
+                                        <div class="text-13 text-gray-300">{{ $teacher->email }}</div>
                                     </div>
                                 </div>
                             </td>
                             <td>
-                                <span class="h6 mb-0 fw-medium text-gray-300">{{ $student->phone ?? '—' }}</span>
+                                <span class="h6 mb-0 fw-medium text-gray-300">{{ $teacher->phone ?? '—' }}</span>
                             </td>
                             <td>
-                                <span class="h6 mb-0 fw-medium text-gray-300">{{ $student->iin ?? '—' }}</span>
+                                <span class="h6 mb-0 fw-medium text-gray-300">{{ $teacher->iin ?? '—' }}</span>
                             </td>
                             <td>
-                                <span class="h6 mb-0 fw-medium text-gray-300">{{ optional($student->birth_date)->format('d.m.Y') ?? '—' }}</span>
+                                <span class="h6 mb-0 fw-medium text-gray-300">{{ optional($teacher->birth_date)->format('d.m.Y') ?? '—' }}</span>
                             </td>
                             <td class="text-end">
                                 <div class="d-inline-flex align-items-center gap-10">
-                                    <a href="{{ route('students.edit', $student) }}" class="text-main-600 text-20 hover-text-main-700" title="Редактировать">
+                                    <a href="{{ route('teachers.edit', $teacher) }}" class="text-main-600 text-20 hover-text-main-700" title="Редактировать">
                                         <i class="ph ph-pencil-simple"></i>
                                     </a>
-                                    <form action="{{ route('students.destroy', $student) }}" method="POST" onsubmit="return confirm('Удалить ученика «{{ $student->name }}»?');">
+                                    <form action="{{ route('teachers.destroy', $teacher) }}" method="POST" onsubmit="return confirm('Удалить учителя «{{ $teacher->name }}»?');">
                                         @csrf
                                         @method('DELETE')
                                         <button type="submit" class="text-danger-600 text-20 bg-transparent border-0 p-0 hover-text-danger-700" title="Удалить">
@@ -95,7 +95,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="5" class="text-center py-4 text-gray-200">Ученики пока не добавлены.</td>
+                            <td colspan="5" class="text-center py-4 text-gray-200">Учителя пока не добавлены.</td>
                         </tr>
                     @endforelse
                 </tbody>
@@ -108,7 +108,7 @@
 @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const tableEl = document.querySelector('#studentsTable');
+            const tableEl = document.querySelector('#teachersTable');
             if (!tableEl || typeof DataTable === 'undefined') {
                 return;
             }

--- a/resources/views/teachers/password.blade.php
+++ b/resources/views/teachers/password.blade.php
@@ -1,0 +1,35 @@
+@extends('welcome')
+
+@section('title', 'Смена пароля учителя')
+@section('page_title', 'Смена пароля')
+@section('page_subtitle', $teacher->name)
+
+@section('page_actions')
+    <a href="{{ route('teachers.show', $teacher) }}" class="btn btn-outline-gray">К профилю</a>
+    <a href="{{ route('teachers.index') }}" class="btn btn-outline-gray">К списку</a>
+@endsection
+
+@section('content')
+    @include('partials.flash')
+
+    <form action="{{ route('teachers.password.update', $teacher) }}" method="POST" class="bg-white border border-gray-100 rounded-16 p-24">
+        @csrf
+        @method('PUT')
+
+        <div class="row g-4">
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Новый пароль *</label>
+                <input type="password" name="password" class="form-control" required>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label fw-semibold">Подтверждение пароля *</label>
+                <input type="password" name="password_confirmation" class="form-control" required>
+            </div>
+        </div>
+
+        <div class="mt-24 d-flex gap-12">
+            <button type="submit" class="btn btn-main">Сохранить</button>
+            <a href="{{ route('teachers.show', $teacher) }}" class="btn btn-outline-gray">Отмена</a>
+        </div>
+    </form>
+@endsection

--- a/resources/views/teachers/show.blade.php
+++ b/resources/views/teachers/show.blade.php
@@ -1,13 +1,13 @@
 @extends('welcome')
 
-@section('title', $student->name)
-@section('page_title', $student->name)
-@section('page_subtitle', 'Ученик')
+@section('title', $teacher->name)
+@section('page_title', $teacher->name)
+@section('page_subtitle', 'Учитель')
 
 @section('page_actions')
-    <a href="{{ route('students.edit', $student) }}" class="btn btn-outline-gray">Редактировать</a>
-    <a href="{{ route('students.password.edit', $student) }}" class="btn btn-outline-gray">Изменить пароль</a>
-    <a href="{{ route('students.index') }}" class="btn btn-outline-gray">К списку</a>
+    <a href="{{ route('teachers.edit', $teacher) }}" class="btn btn-outline-gray">Редактировать</a>
+    <a href="{{ route('teachers.password.edit', $teacher) }}" class="btn btn-outline-gray">Изменить пароль</a>
+    <a href="{{ route('teachers.index') }}" class="btn btn-outline-gray">К списку</a>
 @endsection
 
 @section('content')
@@ -18,19 +18,19 @@
         <div class="row g-4">
             <div class="col-md-6">
                 <div class="text-gray-400 text-sm">Email</div>
-                <div class="fw-semibold">{{ $student->email }}</div>
+                <div class="fw-semibold">{{ $teacher->email }}</div>
             </div>
             <div class="col-md-6">
                 <div class="text-gray-400 text-sm">Телефон</div>
-                <div>{{ $student->phone ?? '—' }}</div>
+                <div>{{ $teacher->phone ?? '—' }}</div>
             </div>
             <div class="col-md-6">
                 <div class="text-gray-400 text-sm">ИИН</div>
-                <div>{{ $student->iin ?? '—' }}</div>
+                <div>{{ $teacher->iin ?? '—' }}</div>
             </div>
             <div class="col-md-6">
                 <div class="text-gray-400 text-sm">Дата рождения</div>
-                <div>{{ optional($student->birth_date)->format('d.m.Y') ?? '—' }}</div>
+                <div>{{ optional($teacher->birth_date)->format('d.m.Y') ?? '—' }}</div>
             </div>
         </div>
     </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -61,6 +61,18 @@
                 'pattern' => 'groups*',
             ],
             [
+                'label' => 'Журнал',
+                'url' => url('/journal'),
+                'icon' => 'ph ph-clipboard-text',
+                'pattern' => 'journal*',
+            ],
+            [
+                'label' => 'Учителя',
+                'url' => url('/teachers'),
+                'icon' => 'ph ph-chalkboard-teacher',
+                'pattern' => 'teachers*',
+            ],
+            [
                 'label' => 'Ученики',
                 'url' => url('/students'),
                 'icon' => 'ph ph-identification-card',

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,11 +2,22 @@
 
 use App\Http\Controllers\CourseController;
 use App\Http\Controllers\GroupController;
+use App\Http\Controllers\JournalController;
 use App\Http\Controllers\StudentController;
+use App\Http\Controllers\TeacherController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', fn () => redirect()->route('groups.index'));
 
 Route::resource('groups', GroupController::class);
+
+Route::get('students/{student}/password/edit', [StudentController::class, 'editPassword'])->name('students.password.edit');
+Route::put('students/{student}/password', [StudentController::class, 'updatePassword'])->name('students.password.update');
 Route::resource('students', StudentController::class);
+
+Route::get('teachers/{teacher}/password/edit', [TeacherController::class, 'editPassword'])->name('teachers.password.edit');
+Route::put('teachers/{teacher}/password', [TeacherController::class, 'updatePassword'])->name('teachers.password.update');
+Route::resource('teachers', TeacherController::class);
+
 Route::resource('courses', CourseController::class);
+Route::get('journal', [JournalController::class, 'index'])->name('journal.index');


### PR DESCRIPTION
## Summary
- rework the student controller and views to capture ФИО, email, ИИН, phone and birth date with a separate password change form and streamlined listing
- add storage and factory support for the new ИИН field on users
- introduce teacher CRUD screens with password updates and expose them from the main navigation

## Testing
- php artisan test *(fails: missing `vendor/autoload.php`)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4cebf5988332880a91b10c2c7f81